### PR TITLE
Fix to correctly display value of properties that store type

### DIFF
--- a/Sources/Reflection/Reflection.swift
+++ b/Sources/Reflection/Reflection.swift
@@ -45,6 +45,8 @@ extension Reflection {
         case number(any Numeric)
         case bool(Bool)
 
+        case type(Any.Type)
+
         case list([Element])
         case dict([(Element, Element)])
         case nested([Element])
@@ -73,6 +75,9 @@ extension Reflection.Element: CustomStringConvertible {
 
         case let .bool(v):
             return "\(v)"
+
+        case let .type(type):
+            return String(reflecting: type).strippedSwiftModulePrefix + ".self"
 
         case let .list(elements):
             if elements.isEmpty { return "[]" }
@@ -114,7 +119,9 @@ extension Reflection {
             return .nil
         }
 
-        let type = "\(mirror.subjectType)"
+        let type: String = .init(reflecting: mirror.subjectType)
+            .strippedSwiftModulePrefix
+
         var element: Element?
 
         switch value {
@@ -142,6 +149,8 @@ extension Reflection {
                 Reflection($0).parse()
             }
             element = .list(elements)
+        case let v as Any.Type:
+            element = .type(v)
         default: break
         }
 

--- a/Sources/Reflection/String+.swift
+++ b/Sources/Reflection/String+.swift
@@ -15,3 +15,16 @@ extension String {
             .joined(separator: "\n")
     }
 }
+
+extension String {
+    package var strippedSwiftModulePrefix: String {
+        var string = self
+        if string.starts(with: "Swift.") {
+            string = String(string.dropFirst(6))
+        }
+        return string
+            .replacingOccurrences(of: "<Swift.", with: "<")
+            .replacingOccurrences(of: "(Swift.", with: "(")
+            .replacingOccurrences(of: ", Swift.", with: ", ")
+    }
+}

--- a/Sources/ReflectionView/ReflectionContentView.swift
+++ b/Sources/ReflectionView/ReflectionContentView.swift
@@ -44,6 +44,15 @@ struct ReflectionContentView: View {
             Text(v.description)
                 .foregroundColor(config.keywordColor)
 
+        case let .type(v):
+            HStack(spacing: 0) {
+                Text(String(reflecting: v).strippedSwiftModulePrefix)
+                    .foregroundColor(config.typeColor)
+                Text(".")
+                Text("self")
+                    .foregroundColor(config.keywordColor)
+            }
+
         case let .list(elements):
             ListContent(
                 type: nil,


### PR DESCRIPTION
| Before | After |
| :---: | :---: |
| <img width="415" alt="スクリーンショット 2025-05-25 19 11 00" src="https://github.com/user-attachments/assets/0657aa34-fe14-4f18-8f5d-2b84c328b191" /> | <img width="415" alt="スクリーンショット 2025-05-25 19 09 30" src="https://github.com/user-attachments/assets/24a92d81-d1da-4aea-a040-8212d22a55cb" /> |

