### PR TITLE
Adjust parsing of NSNumber type values

### DIFF
--- a/Sources/Reflection/Reflection.swift
+++ b/Sources/Reflection/Reflection.swift
@@ -151,6 +151,8 @@ extension Reflection {
             element = .list(elements)
         case let v as Any.Type:
             element = .type(v)
+        case let v as NSNumber:
+            element = .number(v.decimalValue)
         default: break
         }
 


### PR DESCRIPTION
`__NSCFNumber {}` → `__NSCFNumber 123.4` or `__NSCFNumber 567`