### PR TITLE
Fix case name retrieval in enum.

### DIFF
--- a/Sources/Reflection/Reflection.swift
+++ b/Sources/Reflection/Reflection.swift
@@ -201,6 +201,9 @@ extension Reflection {
                         return .enumCase(label ?? "", [Reflection(tuple).parse()])
                     }
                 } else {
+                    if let caseName = _openExistential(value, do: _getEnumCaseName(_:)) {
+                        return .enumCase(String(cString: caseName), [])
+                    }
                     return .enumCase("\(value)", [])
                 }
             }()

--- a/Sources/Reflection/Util.swift
+++ b/Sources/Reflection/Util.swift
@@ -15,3 +15,6 @@ func optionalType(of type: Any.Type) -> Any.Type {
 func _optionalType<T>(_ type: T.Type) -> Any.Type {
     Optional<T>.self
 }
+
+@_silgen_name("swift_EnumCaseName")
+func _getEnumCaseName<T>(_ value: T) -> UnsafePointer<CChar>?


### PR DESCRIPTION
```
<ReflectionViewTests.ShibaInu> {
    name: <String> "aa"
    age: <Int> 0x9
    breed: <ReflectionViewTests.DogBreed> ReflectionViewTests.DogBreed
    color: <String> "blue"
}
```